### PR TITLE
Pass packet and client to ascoltatore in mosca property

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -234,7 +234,7 @@ Server.prototype.serve = function(client) {
       topic: topic,
       payload: payload,
       qos: qos,
-      messageId: (options && options.messageId) || client.nextId++
+      messageId: client.nextId++
     };
 
     actualSend(packet, 0);
@@ -384,10 +384,13 @@ Server.prototype.serve = function(client) {
       that.ascoltatore.publish(
         packet.topic,
         packet.payload,
-        { qos: packet.qos,
-          clientId: client.id,
-          messageId: packet.messageId,
-          user: client.user },
+        {
+          qos: packet.qos,
+          mosca: {
+            client: client, // the client object
+            packet: packet  // the packet being sent
+          }
+        },
         function() {
           debug("client " + client.id + " published packet to topic " + packet.topic);
 

--- a/test/server_spec.js
+++ b/test/server_spec.js
@@ -709,35 +709,6 @@ describe("mosca.Server", function() {
     });
   });
 
-  it("should receive published messageId", function(done) {
-    buildAndConnect(done, function(client) {
-
-      client.once("publish", function(packet) {
-        expect(packet.messageId).to.be.equal(24);
-        client.disconnect();
-      });
-
-      client.on("suback", function(packet) {
-        client.publish({
-          topic: "hello",
-          qos: 1,
-          messageId: 24
-        });
-      });
-
-      var subscriptions = [{
-          topic: "hello",
-          qos: 1
-        }
-      ];
-
-      client.subscribe({
-        subscriptions: subscriptions,
-        messageId: 42
-      });
-    });
-  });
-
   it("should receive all messages at QoS 0 if a subscription is done with QoS 0", function(done) {
     buildAndConnect(done, function(client) {
 
@@ -891,7 +862,7 @@ describe("mosca.Server", function() {
     ]);
   });
 
-  it("should pass username to backend when publishing", function(done) {
+  it("should pass mosca options to backend when publishing", function(done) {
     instance.authenticate = function(client, username, password, callback) {
       expect(username).to.be.eql("matteo");
       expect(password).to.be.eql("collina");
@@ -904,8 +875,8 @@ describe("mosca.Server", function() {
       var messageId = Math.floor(65535 * Math.random());
 
       instance.ascoltatore.subscribe("hello", function (topic, message, options) {
-        expect(options).to.have.property("messageId", messageId);
-        expect(options).to.have.property("user", "matteo");
+        expect(options.mosca.packet).to.have.property("messageId", messageId);
+        expect(options.mosca.client).to.have.property("user", "matteo");
         client.disconnect();
       });
 


### PR DESCRIPTION
Allows ascoltatore to access things like message ID, client ID, user if required.
