### PR TITLE
Client bug on publish authorization

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -51,7 +51,7 @@ Client.prototype._setup = function() {
   });
 
   client.on("publish", function(packet) {
-    that.server.authorizePublish(client, packet.topic, packet.payload, function(err, success) {
+    that.server.authorizePublish(that, packet.topic, packet.payload, function(err, success) {
       that.handleAuthorizePublish(err, success, packet);
     });
   });


### PR DESCRIPTION
The client was not shared between the `authorizePublish` and the `authenticate`. The problem has need fixed and tests added. On the subscribe tests name correction has been applied.
