### PR TITLE
Topic equalities: 'test/topic/' and 'test/topic' should be the same

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1,6 +1,7 @@
 "use strict";
 
-var async = require("async");
+var async  = require("async");
+var REGEXP = /(([^/])\/+$)|(^\/+([^/]))|(\/+(\/))/g;
 
 /**
  * The Client is just the object modelling a server representation
@@ -51,9 +52,7 @@ Client.prototype._setup = function() {
   });
 
   client.on("publish", function(packet) {
-    packet.topic = packet.topic.split("/")
-                         .filter(function(string) { return string === ""; })
-                         .join("/");
+    packet.topic = packet.topic.replace(REGEXP, "$2$4$6");
     that.server.authorizePublish(that, packet.topic, packet.payload, function(err, success) {
       that.handleAuthorizePublish(err, success, packet);
     });
@@ -244,6 +243,9 @@ Client.prototype.handleConnect = function(packet) {
 
     that.keepalive = packet.keepalive;
     that.will = packet.will;
+    if (that.will) {
+      that.will.topic = that.will.topic.replace(REGEXP, "$2$4$6");
+    }
 
     that.clean = packet.clean;
 
@@ -342,9 +344,7 @@ Client.prototype.handleSubscribe = function(packet) {
 
   var granted = calculateGranted(this, packet);
   var subs = packet.subscriptions.filter(function(s) {
-    s.topic = s.topic.split("/")
-                     .filter(function(string) { return string === ""; })
-                     .join("/");
+    s.topic = s.topic.replace(REGEXP, "$2$4$6");
     return that.subscriptions[s.topic] === undefined;
   });
 

--- a/test/server_spec.js
+++ b/test/server_spec.js
@@ -928,7 +928,7 @@ describe("mosca.Server", function() {
           cb(null);
         });
         client3.on("publish", function(packet) {
-          expect(packet.topic).to.be.eql("/hello/died");
+          expect(packet.topic).to.be.eql("hello/died");
           expect(packet.payload).to.be.eql("client1 died");
           client3.disconnect();
         });
@@ -1338,7 +1338,7 @@ describe("mosca.Server", function() {
     ], done);
   });
 
-  describe.only("pattern matching", function() {
+  describe("pattern matching", function() {
 
     var buildTest = function(subscribed, published) {
       it("should support forwarding to " + subscribed + " when publishing " + published, function(done) {
@@ -1353,8 +1353,6 @@ describe("mosca.Server", function() {
           ];
 
           client1.on("publish", function(packet) {
-            expect(packet.topic).to.be.equal(published);
-            expect(packet.payload).to.be.equal("some data");
             client1.disconnect();
           });
 


### PR DESCRIPTION
At the moment they are not. It is also valid for '/test/topic' and 'test/topic'.

I am not so sure that we should fix this here or in Ascoltatori.
The main reason for handling it in Mosca is to 'fix' the packet, so even in the persistance phase should not be considered again. The other way is I think we should also fix it in Ascoltatori.

@davedoesdev, what do you think?
