### PR TITLE
Call unsubAndClose on client timeout instead of close.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -112,7 +112,7 @@ Client.prototype.setUpTimer = function() {
 
   this.timer = setTimeout(function() {
     that.logger.info("keepalive timeout");
-    that.close();
+    that.unsubAndClose();
   }, timeout);
 };
 


### PR DESCRIPTION
Noticed the error: "tryint to send a packet to a disconnected client" after a mosca was running for a while. Traced it down to timed out clients not calling the correct close method. They should be calling unsubAndClose instead of just close.  Tried to add a test case for this, but wasn't able to successfully repro this in the unit test framework. 
