### PR TITLE
Keep calm and redis on if no client to clean.

### DIFF
--- a/lib/persistence/redis.js
+++ b/lib/persistence/redis.js
@@ -206,7 +206,8 @@ RedisPersistence.prototype._cleanClient = function(client, done) {
     var key = "client:sub:" + client.id;
 
     this._client.get(key, function(err, subs) {
-      subs = JSON.parse(subs);
+      subs = JSON.parse(subs) || {};
+
       Object.keys(subs).forEach(function(sub) {
         that._subLobber.remove(sub, client.id);
       });


### PR DESCRIPTION
When attempting to use Redis as a QoS 1 persistence factory, the following command...

```
mosquitto_pub -t "hello" -m "world"
```

...makes mosca explode...

```
/home/wat/foo/node_modules/mosca/node_modules/redis/index.js:551
            throw err;
                  ^
TypeError: Object.keys called on non-object
    at Function.keys (native)
    at /home/wat/foo/node_modules/mosca/lib/persistence/redis.js:212:14
    at try_callback (/home/wat/foo/node_modules/mosca/node_modules/redis/index.js:548:9)
    at RedisClient.return_reply (/home/wat/foo/node_modules/mosca/node_modules/redis/index.js:630:13)
    at ReplyParser.<anonymous> (/home/wat/foo/node_modules/mosca/node_modules/redis/index.js:282:14)
    at ReplyParser.EventEmitter.emit (events.js:95:17)
    at ReplyParser.send_reply (/home/wat/foo/node_modules/mosca/node_modules/redis/lib/parser/javascript.js:300:10)
    at ReplyParser.execute (/home/wat/foo/node_modules/mosca/node_modules/redis/lib/parser/javascript.js:203:22)
    at RedisClient.on_data (/home/wat/foo/node_modules/mosca/node_modules/redis/index.js:504:27)
    at Socket.<anonymous> (/home/wat/foo/node_modules/mosca/node_modules/redis/index.js:82:14)
```

This happens when a null is gotten back from Redis in _cleanClient().
