### PR TITLE
Don't emit clientDisconnected event when force close client.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -455,6 +455,8 @@ Client.prototype.handleAuthorizePublish = function(err, success, packet) {
 Client.prototype.onNonDisconnectClose = function() {
   var that = this, logger = that.logger;
 
+  that._streamClosedRequiresCleanup = true;
+
   if (that.will) {
     logger.info({ willTopic: that.will.topic }, "delivering last will");
     that.server.ascoltatore.publish(
@@ -511,10 +513,6 @@ Client.prototype.close = function(callback) {
       callback();
     }
   };
-
-  that.connection.stream.on('end' , function(){
-    that._streamClosedRequiresCleanup = true;
-  });
 
   that._closing = true;
 

--- a/test/abstract_server.js
+++ b/test/abstract_server.js
@@ -649,6 +649,23 @@ module.exports = function(moscaSettings, createConnection) {
     client.connect(buildOpts());
   });
 
+  it("should emit an event when a client is disconnected without a disconnect", function(done) {
+    var client = createConnection(settings.port, settings.host);
+
+    instance.once('clientDisconnected', function(serverClient) {
+      expect(serverClient).not.to.be.equal(undefined);
+      done();
+    });
+
+    client.on('error', done);
+
+    client.on('connack', function() {
+      client.stream.end();
+    });
+
+    client.connect(buildOpts());
+  });
+
   it("should emit a ready and closed events", function(done) {
     var server = new mosca.Server(moscaSettings());
     async.series([


### PR DESCRIPTION
Hi, I got a problem. When I force close a client use `CTRL+C` , Mosca not emit `clientDisconnected` event. Here is the code:
- Server

``` js
var server = new mosca.Server(options);
server.on('clientDisconnected', function () {
    console.log('client gone');
})
```
- Client

``` js
var client = mqtt.createClient();
// Works fine, mosca got the clientDisconnected event.
client.end();
```

``` js
var client = mqtt.createClient();
// Use CTRL+C kill the process and mosca not got the clientDisconnected event.
```
