### PR TITLE
Return proper error on authentication failure

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -269,6 +269,9 @@ Client.prototype.handleConnect = function(packet) {
 
     if (err) {
       logger.info({ username: packet.username }, "authentication error");
+      client.connack({
+        returnCode: 4
+      });  
       client.stream.end();
       that.connection.emit("error", err);
       return;


### PR DESCRIPTION
An error indicating username/password problem is sent to the client on connect
