### PR TITLE
Update secureEmbedded.js

### DIFF
--- a/examples/secure/secureEmbedded.js
+++ b/examples/secure/secureEmbedded.js
@@ -4,12 +4,12 @@ var SECURE_KEY = __dirname + '/../../test/secure/tls-key.pem';
 var SECURE_CERT = __dirname + '/../../test/secure/tls-cert.pem';
 
 var settings = {
-  port: 8443,
   logger: {
     name: "secureExample",
     level: 40,
   },
   secure : { 
+    port: 8443,
     keyPath: SECURE_KEY,
     certPath: SECURE_CERT,
   }


### PR DESCRIPTION
Default Secure port is override by that.opts.secure.port = that.opts.secure.port || 8883; instead of opts.port
