### PR TITLE
Fix for unsubscribe before subscribe scenario

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -257,7 +257,7 @@ Client.prototype.unsubscribeMapTo = function(topic) {
   var that = this;
   return function(cb) {
     var sub = that.subscriptions[topic];
-    if (!sub && !sub.handler) {
+    if (!sub || !sub.handler) {
       return cb();
     }
 


### PR DESCRIPTION
If mqtt client send unsubscribe message before any subscribe message. The (!sub || !sub.handler) expression would raise an exception.
