### PR TITLE
Correcting server.deleteOfflinePacket param name

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -395,7 +395,7 @@ Server.prototype.storePacket = function(packet, callback) {
  * @param {Number} messageId The messsageId of the packet
  * @param {Function} callback
  */
-Server.prototype.deleteOfflinePacket = function(packet, messageId, callback) {
+Server.prototype.deleteOfflinePacket = function(client, messageId, callback) {
   if (callback) {
     callback();
   }


### PR DESCRIPTION
All implementation and invocation of `server.deleteOfflinePacket` takes first argument as `client` instead of `packet`.
