### PR TITLE
add opts.forwardFilter

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -226,15 +226,17 @@ Client.prototype._buildForward = function() {
                 );
 
     function doForward() {
-      if(that.server.opts.forwardFilter && that.server.opts.forwardFilter(that, packet, qos)) {
-        return;
-      }
+      that.server.authorizeForward(that, packet, qos, function(err, authorized) {
+        if (err || !authorized) {
+          return;
+        }
 
-      that.connection.publish(packet);
+        that.connection.publish(packet);
 
-      if (packet.qos === 1) {
-        that.inflight[packet.messageId] = packet;
-      }
+        if (packet.qos === 1) {
+          that.inflight[packet.messageId] = packet;
+        }
+      });
     }
 
     if (forward) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -91,8 +91,6 @@ var nop = function() {};
  *     - `bundle`, serve the bundled mqtt client
  *     - `static`, serve a directory
  *  - `stats`, publish the stats every 10s (default false).
- *  - `forwardFilter`, funciton to be called whenever a packet is forwarded. The three arguments are client, packet and qos.
- *     If invocation to `forwardFilter` returns false, the packet is not forwarded. Otherwise, it is forwarded.
  *
  * Events:
  *  - `clientConnected`, when a client is connected;
@@ -371,6 +369,22 @@ Server.prototype.authorizePublish = function(client, topic, payload, callback) {
 Server.prototype.authorizeSubscribe = function(client, topic, callback) {
   callback(null, true);
 };
+
+/**
+ * The function that will be used to authorize forwarding packet to client.
+ * This default implementation authorize any packet for any client.
+ * Override at will
+ *
+ * @api public
+ * @param {Object} client The MQTTConnection that is a client
+ * @param {Object} packet The packet
+ * @param {Number} qos The QoS
+ * @param {Function} callback The callback to return the verdict
+ */
+Server.prototype.authorizeForward = function(client, packet, qos, callback) {
+  callback(null, true);
+};
+
 
 /**
  * Store a packet for future usage, if needed.

--- a/test/abstract_server.js
+++ b/test/abstract_server.js
@@ -1255,6 +1255,52 @@ module.exports = function(moscaSettings, createConnection) {
     });
   });
 
+  it("should not forward packet if authorizeForward returns false", function(done) {
+    var d = donner(2, done);
+    var that = this;
+
+    this.instance.authorizeForward = function(client, packet, qos, callback) {
+      callback(null, packet.topic != 'stop_forward');
+    };
+
+    buildAndConnect(d, buildOpts(), function(client1) {
+      var messageId = Math.floor(65535 * Math.random());
+
+      var subscriptions = [
+        { topic : "stop_forward", qos : 1 },
+        { topic : "go_forward", qos : 1 }
+      ];
+
+      client1.on("publish", function(packet) {
+        expect(packet.topic).to.equal("go_forward");
+      });
+      client1.on("suback", function() {
+        buildAndConnect(d, buildOpts(), function(client2) {
+          client2.on("puback", function(packet) {
+            client1.disconnect();
+            client2.disconnect();
+          });
+          client2.publish({
+            topic: "stop_forward",
+            messageId: messageId,
+            qos: 1
+          });
+
+          client2.publish({
+            topic: "go_forward",
+            messageId: messageId,
+            qos: 1
+          });
+        });
+      });
+
+      client1.subscribe({
+        subscriptions: subscriptions,
+        messageId: messageId
+      });
+    });
+  });
+
   it("should support retained messages", function(done) {
 
     async.waterfall([

--- a/test/server.js
+++ b/test/server.js
@@ -14,9 +14,6 @@ var moscaSettings = function() {
     logger: {
       childOf: globalLogger,
       level: 60
-    },
-    forwardFilter: function(client, packet, qos) {
-      return packet.topic == 'stop_forward';
     }
   };
 };
@@ -54,50 +51,6 @@ describe("mosca.Server", function() {
       });
     });
   }
-
-  it("should not forward packet if opts.forwardFilter returns false", function(done) {
-    var d = donner(2, done);
-    var that = this;
-    buildAndConnect(d, this.instance, buildOpts(), function(client1) {
-
-      var messageId = Math.floor(65535 * Math.random());
-
-      var subscriptions = [
-        { topic : "stop_forward", qos : 1 },
-        { topic : "go_forward", qos : 1 }
-      ];
-
-      client1.on("publish", function(packet) {
-        expect(packet.topic).to.equal("go_forward");
-      });
-
-      client1.on("suback", function() {
-        buildAndConnect(d, that.instance, buildOpts(), function(client2) {
-
-          client2.on("puback", function(packet) {
-            client1.disconnect();
-            client2.disconnect();
-          });
-          client2.publish({
-            topic: "stop_forward",
-            messageId: messageId,
-            qos: 1
-          });
-
-          client2.publish({
-            topic: "go_forward",
-            messageId: messageId,
-            qos: 1
-          });
-        });
-      });
-
-      client1.subscribe({
-        subscriptions: subscriptions,
-        messageId: messageId
-      });
-    });
-  });
 
   it("should close twice", function(done) {
     this.instance.close(done);


### PR DESCRIPTION
This is just a proposal.

This change comes from real product requirement. Our application require different message packets have different expiration TTL. However, there is one `ttl.packets` option for all packets in Mosca currently. 

For the time being, our application has one tweak on Mosca as this PR suggests. For each packet, when it is actually `forward`-ed, a callback function in `opts` is invoked. This gives a chance to application layer to decide whether this packet is expired or not. Our packet payload has `ts` and `ttl` field, so that application layer can return `true` or `false` accordingly. If `true` is returned, the packet is not forwared. If `false` is returned, the packet is forwarded as shown green light.

I believe that other application should have same requirements. 

Is there any better approach to fulfil the need?
