### PR TITLE
allow persistence.factory in options to be string

### DIFF
--- a/lib/persistence/index.js
+++ b/lib/persistence/index.js
@@ -33,3 +33,12 @@ module.exports.Memory = require("./memory");
 module.exports.LevelUp = require("./levelup");
 module.exports.Redis = require("./redis");
 module.exports.Mongo = require("./mongo");
+
+var factories = {};
+Object.keys(module.exports).forEach(function(type) {
+  factories[type.toLowerCase()] = module.exports[type];
+});
+
+module.exports.getFactory = function(name) {
+  return factories[name.toLowerCase()];
+};

--- a/lib/server.js
+++ b/lib/server.js
@@ -125,23 +125,16 @@ function Server(opts, callback) {
 
   var persistenceFactory = this.opts.persistence && this.opts.persistence.factory;
   if (persistenceFactory) {
-    if (typeof persistenceFactory == 'string') {
-      var persistenceName = persistenceFactory;
-
-      var factories = {};
-      Object.keys(persistence).forEach(function(type) {
-        factories[type.toLowerCase()] = persistence[type];
-      });
-
-      persistenceFactory = factories[persistenceName.toLowerCase()];
+    if (typeof persistenceFactory === 'string') {
+      var factoryName = persistenceFactory;
+      persistenceFactory = persistence.getFactory(factoryName);
       if (!persistenceFactory) {
-        return callback('No persistence factory found for ' + persistenceName);
+        return callback(new Error('No persistence factory found for ' + factoryName ));
       }
     }
 
     persistenceFactory(this.opts.persistence).wire(this);
   }
-
 
   this._dedupId = 0;
   this.clients = {};

--- a/test/server.js
+++ b/test/server.js
@@ -765,7 +765,7 @@ describe("mosca.Server - MQTT backend", function() {
     ], done);
   });
 
-  it("should faili if persistence string is not correct", function(done) {
+  it("should fail if persistence string is not correct", function(done) {
     var newSettings = moscaSettings();
 
     newSettings.persistence = {
@@ -775,8 +775,11 @@ describe("mosca.Server - MQTT backend", function() {
     };
 
     var server = new mosca.Server(newSettings, function(err) {
-      expect(err).to.be.a('string');
-      done();
+      if(err instanceof Error) {
+        done();
+      } else {
+        expect().fail('new mosca.Server should fail');
+      }
     });
 
   });


### PR DESCRIPTION
To fix https://github.com/mcollina/mosca/issues/126

Should we allow `factory` to be either Function or String? or have a new option field `type` in `persistence`?
