### PR TITLE
publish subscribes and connected-client

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -49,6 +49,7 @@ var defaults = {
     wildcardSome: '#'
   },
   stats: true,
+  publishNewClient: true,
   maxInflightMessages: 1024,
   logger: {
     name: "mosca",

--- a/test/abstract_server.js
+++ b/test/abstract_server.js
@@ -9,6 +9,7 @@ module.exports = function(moscaSettings, createConnection) {
 
   beforeEach(function(done) {
     settings = moscaSettings();
+    settings.publishNewClient = false;
     instance = new mosca.Server(settings, done);
     this.instance = instance;
     this.settings = settings;

--- a/test/server.js
+++ b/test/server.js
@@ -8,6 +8,7 @@ var moscaSettings = function() {
   return {
     port: nextPort(),
     stats: false,
+    publishNewClient: false,
     persistence: {
       factory: mosca.persistence.Memory
     },

--- a/test/server_mongo.js
+++ b/test/server_mongo.js
@@ -31,6 +31,7 @@ describe("mosca.Server with mongo persistence", function() {
     return {
       port: nextPort(),
       stats: false,
+      publishNewClient: false,
       logger: {
         childOf: globalLogger,
         level: 60

--- a/test/server_redis.js
+++ b/test/server_redis.js
@@ -19,6 +19,7 @@ describe("mosca.Server with redis persistence", function() {
     return {
       port: nextPort(),
       stats: false,
+      publishNewClient: false,
       logger: {
         childOf: globalLogger,
         level: 60


### PR DESCRIPTION
Fix #92

Publish new client by default would break a lot of unit test cases. So, I add one `server.options` named `publishNewClient` to switch the feature, which is off by default.
