### PR TITLE
fix bug of key conatains dot

### DIFF
--- a/lib/persistence/mongo.js
+++ b/lib/persistence/mongo.js
@@ -303,7 +303,8 @@ MongoPersistence.prototype.streamOfflinePackets = function(client, cb) {
 MongoPersistence.prototype.deleteOfflinePacket = function(client, messageId, cb) {
   var toSearch = {
     client: client.id,
-    'packet.messageId': messageId
+    //'packet.messageId': messageId
+    packet: {"messageId": messageId}
   };
 
   this._packets.remove(toSearch, {w:1}, cb);
@@ -312,9 +313,13 @@ MongoPersistence.prototype.deleteOfflinePacket = function(client, messageId, cb)
 MongoPersistence.prototype.updateOfflinePacket = function(client, messageId, packet, cb) {
   this._packets.update({
     client: client.id,
-    'packet.messageId': messageId
+    //'packet.messageId': messageId
+    packet: {"messageId": messageId}
   }, {
-    $set: { 'packet.messageId': packet.messageId }
+    //$set: { 'packet.messageId': packet.messageId }
+    $set: {
+        packet: {"messageId": messageId}
+    }
   }, {w:1}, function(err) {
     cb(err, packet);
   });


### PR DESCRIPTION
When I used mosca, I found an exception that key contains dot in mongo.js. After some modifications of the update and search operation of mongo db, it was fixed.
By the way, I don't know why the exception would appear, as I searched  on the internet and found that there was no problem using dot to perform nested search.
