### PR TITLE
fix code example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ npm install mosca --save
 Show me some code:
 
 ```javascript
-var mosca = require('mosca')
+var mosca = require('mosca');
 
 var ascoltatore = {
   //using ascoltatore
@@ -55,6 +55,8 @@ var settings = {
   backend: ascoltatore
 };
 
+var server = new mosca.Server(settings);
+
 server.on('clientConnected', function(client) {
     console.log('client connected', client.id);
 });
@@ -64,12 +66,11 @@ server.on('published', function(packet, client) {
   console.log('Published', packet.payload);
 });
 
-var server = new mosca.Server(settings);
 server.on('ready', setup);
 
 // fired when the mqtt server is ready
 function setup() {
-  console.log('Mosca server is up and running')
+  console.log('Mosca server is up and running');
 }
 ```
 


### PR DESCRIPTION
server was referenced before it was instantiated.

semicolons were just for consistency