### PR TITLE
refactoring in persistence

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -77,6 +77,8 @@ Client.prototype._setup = function() {
 
       that.logger.info("client connected");
       that.server.emit("clientConnected", that);
+
+      // packets will be forward only if client.clean is false
       that.server.forwardOfflinePackets(that);
     });
 

--- a/lib/persistence/abstract.js
+++ b/lib/persistence/abstract.js
@@ -116,6 +116,11 @@ AbstractPersistence.prototype.wire = function(server) {
   };
 
   server.forwardOfflinePackets = function(client, done) {
+    // do not waste cpu time find in stored packets...
+    // if client is clean lookupSubscriptions already delete stored packets
+    if(client.clean)
+      return done && done();
+
     that.streamOfflinePackets(client, function(err, packet) {
       packet.offline = true;
       client.logger.debug({ packet: packet }, "Forwarding offline packet");

--- a/lib/persistence/mongo.js
+++ b/lib/persistence/mongo.js
@@ -292,10 +292,7 @@ MongoPersistence.prototype._storePacket = function(client, packet, cb) {
 };
 
 MongoPersistence.prototype.streamOfflinePackets = function(client, cb, done) {
-  if (client.clean) {
-    return;
-  }
-
+ 
   var stream = this._packets.find({ client: client.id }).stream();
   var that = this;
 

--- a/lib/persistence/redis.js
+++ b/lib/persistence/redis.js
@@ -268,69 +268,53 @@ RedisPersistence.prototype.storeSubscriptions = function(client, cb) {
 
 RedisPersistence.prototype._cleanClient = function(client, done) {
   var that = this;
-  if (client.clean) {
-    var key = "client:sub:" + client.id;
+ 
+  var key = "client:sub:" + client.id;
 
-    this._client.get(key, function(err, subs) {
-      subs = JSON.parse(subs) || {};
+  this._client.get(key, function(err, subs) {
+    subs = JSON.parse(subs) || {};
 
-      Object.keys(subs).forEach(function(sub) {
-        that._subMatcher.remove(sub, client.id);
-      });
-
-      async.parallel([
-        function(cb) {
-          that._client.del(key, cb);
-        },
-        function(cb) {
-          that._client.del("packets:" + client.id, cb);
-        }
-      ], function(err) {
-        if (done) {
-          done(err, {});
-        }
-      });
+    Object.keys(subs).forEach(function(sub) {
+      that._subMatcher.remove(sub, client.id);
     });
 
-    return true;
-  }
-
-  return false;
+    async.parallel([
+      function(cb) {
+        that._client.del(key, cb);
+      },
+      function(cb) {
+        that._client.del("packets:" + client.id, cb);
+      }
+    ], function(err) {
+      if (done) {
+        done(err, {});
+      }
+    });
+  });  
 };
-
 
 RedisPersistence.prototype.lookupSubscriptions = function(client, cb) {
   if (this._explicitlyClosed()) {
     return cb && cb(new Error('Explicitly closed'));
   }
-  if (this._cleanClient(client, cb)) {
-    return;
-  }
-
-  var key = "client:sub:" + client.id;
-  var subscriptions;
-
-  var multi = this._client.multi();
-  var that = this;
-
-  multi.get(key, function(err, result) {
-
-    subscriptions = JSON.parse(result) || {};
-
-    if (client.clean) {
-      Object.keys(subscriptions).forEach(function(sub) {
-        that._subMatcher.remove(sub, client.id);
-      });
-    }
-  });
 
   if (client.clean) {
-    multi.del(key);
-  }
+    this._cleanClient(client, cb);
+  }else{
+    var key = "client:sub:" + client.id;
+    var subscriptions;
 
-  multi.exec(function(err) {
-    cb(err, subscriptions);
-  });
+    var multi = this._client.multi();
+    var that = this;
+
+    multi.get(key, function(err, result) {
+      subscriptions = JSON.parse(result) || {};   
+    });
+
+    multi.exec(function(err) {
+      cb(err, subscriptions);
+    });
+  }
 };
 
 RedisPersistence.prototype.storeOfflinePacket = function(packet, done) {
@@ -370,10 +354,6 @@ RedisPersistence.prototype.streamOfflinePackets = function(client, cb, done) {
 
   var that = this,
       listKey = "packets:" + client.id;
-
-  if (this._cleanClient(client)) {
-    return;
-  }
 
   that._client.lrange(listKey, 0, 10000, function(err, results) {
 

--- a/test/abstract_server.js
+++ b/test/abstract_server.js
@@ -1761,6 +1761,73 @@ module.exports = function(moscaSettings, createConnection) {
     ], done);
   });
 
+  it("cleanSession = false, on reconnect cleanSession = true", function(done) {
+    var opts = buildOpts();
+
+    opts.clientId = "mosca-unclean-client-test";
+
+    async.series([
+
+      function(cb) {
+        opts.clean = false;
+        buildAndConnect(cb, opts, function(client, connack) {
+
+          // sessionPresent must be false
+          expect(connack.sessionPresent).to.be.eql(false);
+
+          var subscriptions = [{
+            topic: "hello",
+            qos: 1
+          }];
+
+          client.subscribe({
+            subscriptions: subscriptions,
+            messageId: 42
+          });
+
+          client.on("suback", function() {
+            client.stream.end();
+          });
+        });
+      },
+
+      function(cb) {
+        buildAndConnect(cb, buildOpts(), function(client, connack) {
+
+          // buildOpts create new id, so is new session, sessionPresent must be false
+          expect(connack.sessionPresent).to.be.eql(false);
+
+          client.publish({
+            topic: "hello",
+            qos: 1,
+            payload: "world",
+            messageId: 24
+          });
+          client.on("puback", function() {
+            client.disconnect();
+          });
+        });
+      },
+
+      function(cb) {
+        opts.clean = true;
+        buildAndConnect(cb, opts, function(client, connack) {
+
+          // reconnection sessionPresent must be false, it is clean
+          expect(connack.sessionPresent).to.be.eql(false);
+          
+          client.on("publish", function(packet) {
+            cb(new Error("unexpected publish"));
+          });
+
+          setTimeout(function(){
+            client.disconnect();
+          }, 1000);
+        });
+      }
+    ], done);
+  });
+
   it("should remove already pubacked messages from the offline store", function(done) {
     var opts = buildOpts();
 

--- a/test/persistence/abstract.js
+++ b/test/persistence/abstract.js
@@ -738,7 +738,10 @@ module.exports = function(create, buildOpts) {
     });
 
     it("should not stream any offline packet to a clean client", function(done) {
+      var server = new EventEmitter();
       var instance = this.instance;
+      instance.wire(server);
+
       var client = {
         id: "my client id - 42",
         clean: false,
@@ -752,10 +755,7 @@ module.exports = function(create, buildOpts) {
 
       instance.storeOfflinePacket(packet, function() {
         client.clean = true;
-        instance.streamOfflinePackets(client, function(err, p) {
-          done(new Error("this should never be called"));
-        });
-        done();
+        server.forwardOfflinePackets(client, done);
       });
     });
 

--- a/test/persistence/levelup_spec.js
+++ b/test/persistence/levelup_spec.js
@@ -9,7 +9,7 @@ var rimraf = require("rimraf");
 
 describe("mosca.persistence.LevelUp", function() {
 
-  this.timeout(2000);
+  this.timeout(4000);
 
   var opts = {
     ttl: {

--- a/test/persistence/mongo_spec.js
+++ b/test/persistence/mongo_spec.js
@@ -8,6 +8,8 @@ var async = require("async");
 
 describe("mosca.persistence.Mongo", function() {
 
+  this.timeout(4000);
+
   var opts = {
     url: "mongodb://localhost:27017/moscatests",
     autoClose: false,

--- a/test/persistence/redis_spec.js
+++ b/test/persistence/redis_spec.js
@@ -6,6 +6,8 @@ var redis = require("redis");
 
 describe("mosca.persistence.Redis", function() {
 
+  this.timeout(5000);
+
   var opts = {
     ttl: {
       subscriptions: 1000,


### PR DESCRIPTION
in mongodb, levelup and redis the functions lookupSubscriptions and streamOfflinePackets do different works, this commit unified the behaviors of functions. if client is clean lookupSubscriptions must be delete stored subscriptions and packets.

streamOfflinePackets function do not delete stored packets on clean client.

i remove unnecessary some double check of clean flag for better perfomance.