### PR TITLE
Support for certificate authority paths

### DIFF
--- a/lib/interfaces.js
+++ b/lib/interfaces.js
@@ -86,6 +86,13 @@ function mqttsFactory(iface, fallback, mosca) {
     credentials.cert = fs.readFileSync(credentials.certPath);
   }
 
+  if (credentials.caPaths) {
+    credentials.ca = [];
+    credentials.caPaths.forEach(function (caPath) {
+    	credentials.ca.push(fs.readFileSync(caPath));
+    });
+  }
+
   return tls.createServer(credentials, buildWrap(mosca));
 }
 
@@ -109,6 +116,13 @@ function httpsFactory(iface, fallback, mosca) {
 
   if (credentials.certPath) {
     credentials.cert = fs.readFileSync(credentials.certPath);
+  }
+
+  if (credentials.caPaths) {
+    credentials.ca = [];
+    credentials.caPaths.forEach(function (caPath) {
+    	credentials.ca.push(fs.readFileSync(caPath));
+    });
   }
 
   var serve = buildServe(iface, mosca);

--- a/lib/options.js
+++ b/lib/options.js
@@ -204,6 +204,7 @@ function validate(opts, validationOptions) {
     properties: {
       'keyPath': { type: 'string', required: true },
       'certPath': { type: 'string', required: true },
+      'caPaths': { type: 'array', required: false }
     }
   });
 


### PR DESCRIPTION
To use, add this to server constructor options:
credentials.caPaths = ['/ca/cert-1.pem', '/ca/cert-2.pem']