### PR TITLE
Make sure 'nextId' always fits in a uint8. (#304)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -42,7 +42,7 @@ function Client(conn, server) {
   this.logger = server.logger;
   this.subscriptions = {};
 
-  this.nextId = 1;
+  this.nextId = 0;
   this.inflight = {};
   this.inflightCounter = 0;
   this._lastDedupId = -1;
@@ -213,6 +213,9 @@ Client.prototype._buildForward = function() {
         indexPlus = subTopic.indexOf("+"),
         forward = true,
         newId = this.nextId++;
+
+    // Make sure 'nextId' always fits in a uint8 (http://git.io/vmgKI).
+    this.nextId %= 65536;
 
     var packet = {
       topic: topic,


### PR DESCRIPTION
This fixes #304. I've chosen to use 0 as the first value for `nextId` as it keeps things simpler and (at least for me) is more intuitive.