### PR TITLE
Make offline message lifetime a option of server settings.

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -67,6 +67,8 @@ function modernize(legacy) {
     }
   });
 
+
+
   // TODO: copy `backend` carefully
   if (legacy.hasOwnProperty('backend')) {
     modernized.backend = legacy.backend;
@@ -80,6 +82,11 @@ function modernize(legacy) {
   // TODO: copy `persistence` carefully
   if (legacy.hasOwnProperty('persistence')) {
     modernized.persistence = legacy.persistence;
+  }
+
+  // OfflineMessageTimeout, in milliseconds, put -1 to make if forever stored.
+  if (legacy.hasOwnProperty("offlineMessageTimeout")){
+    modernized.persistence.offlinePacketsTimeout = modernized.offlineMessageTimeout = legacy.offlineMessageTimeout;
   }
 
   // TODO: copy `logger` carefully
@@ -236,7 +243,7 @@ function validate(opts, validationOptions) {
       'ascoltatore': { type: 'object' }, // TODO
       'persistence': { type: 'object' }, // TODO
       'logger': { type: 'object' },      // TODO
-
+      'offlineMessageTimeout' : { type: 'integer'},
       'maxInflightMessages': { type: 'integer' },
       'stats': { type: 'boolean' },
       'publishNewClient': { type: 'boolean' },

--- a/lib/persistence/abstract.js
+++ b/lib/persistence/abstract.js
@@ -27,6 +27,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 var async = require("async");
 var EventEmitter = require("events").EventEmitter;
 var util = require("util");
+
 /**
  * An Abstract Mosca persistance implementation
  *
@@ -49,9 +50,7 @@ AbstractPersistence.prototype.wire = function(server) {
   var that = this;
   var nop = function() {};
   server.persistence = this;
-  that.agendaClient = server.agendaClient;
 
-  //that.agendaClient = server.agendaClient;
   server.storePacket = function(packet, cb) {
 
     // store qos 0 packets only if storeMessagesQos0 is true or retain is true

--- a/lib/persistence/abstract.js
+++ b/lib/persistence/abstract.js
@@ -27,7 +27,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 var async = require("async");
 var EventEmitter = require("events").EventEmitter;
 var util = require("util");
-
 /**
  * An Abstract Mosca persistance implementation
  *
@@ -50,7 +49,9 @@ AbstractPersistence.prototype.wire = function(server) {
   var that = this;
   var nop = function() {};
   server.persistence = this;
+  that.agendaClient = server.agendaClient;
 
+  //that.agendaClient = server.agendaClient;
   server.storePacket = function(packet, cb) {
 
     // store qos 0 packets only if storeMessagesQos0 is true or retain is true

--- a/lib/persistence/mongo.js
+++ b/lib/persistence/mongo.js
@@ -267,10 +267,23 @@ MongoPersistence.prototype.storeOfflinePacket = function(packet, done) {
       // TODO handle the err in case of no callback
       completed++;
 
+
+      //Add agenda task to remove the unreceived packets accordingly.
+      if (that.agendaClient)
+      {
+        that.agendaClient.schedule(that.agendaClient.getExpireDate(), that.agendaClient.AGENDA_TASK_REMOVE, {
+          clientId: data.client,
+          msgId: packet.messageId,
+          jobTag: data.client + '|' + packet.messageId,
+          removeOnDone: true,
+        })
+      }
+
       if (done && ended && started === completed) {
         done();
       }
     });
+
   });
 
   stream.on("end", function() {

--- a/lib/persistence/mongo.js
+++ b/lib/persistence/mongo.js
@@ -267,23 +267,10 @@ MongoPersistence.prototype.storeOfflinePacket = function(packet, done) {
       // TODO handle the err in case of no callback
       completed++;
 
-
-      //Add agenda task to remove the unreceived packets accordingly.
-      if (that.agendaClient)
-      {
-        that.agendaClient.schedule(that.agendaClient.getExpireDate(), that.agendaClient.AGENDA_TASK_REMOVE, {
-          clientId: data.client,
-          msgId: packet.messageId,
-          jobTag: data.client + '|' + packet.messageId,
-          removeOnDone: true,
-        })
-      }
-
       if (done && ended && started === completed) {
         done();
       }
     });
-
   });
 
   stream.on("end", function() {

--- a/lib/persistence/mongo.js
+++ b/lib/persistence/mongo.js
@@ -38,7 +38,8 @@ var defaults = {
     subscriptions: 60 * 60 * 1000,
 
     // TTL for packets is 1 hour
-    packets: 60 * 60 * 1000,
+    packets: 60* 60 * 1000, //60 * 60 * 1000,
+
   },
   mongo: {},
   storeMessagesQos0: false
@@ -73,6 +74,10 @@ function MongoPersistence(options, done) {
 
   this.options = extend(true, {}, defaults, options);
   this.options.mongo.safe = true;
+  if (options.offlinePacketsTimeout)
+  {
+    this.options.ttl.packets = options.offlinePacketsTimeout;
+  }
 
   var that = this;
 
@@ -101,7 +106,39 @@ function MongoPersistence(options, done) {
           that._packets = coll;
           async.parallel([
             that._packets.ensureIndex.bind(that._packets, "client"),
-            that._packets.ensureIndex.bind(that._packets, { "added": 1 }, { expireAfterSeconds: Math.round(that.options.ttl.packets / 1000 )} )
+            function()
+            {
+              //Check expiration indexex. If not exist, create; If exist but with different ttl, delete and recreate; Otherwise, do nothing.
+              that._packets.indexes(function(error, colIndexes){
+                if (error)
+                {
+                  cb(error);
+                }
+                else {
+                  var addedIndexKey = {"added": 1};
+                  var addedIndexKeyString = 'added_1'; // If addedIndex changes, this value should also be changed accordingly.
+                  var addedIndexObj = colIndexes.filter(function(obj){
+                    return obj.name == addedIndexKeyString;
+                  });
+                  if (addedIndexObj.length <= 0 || addedIndexObj[0].expireAfterSeconds != Math.round(that.options.ttl.packets / 1000)) {
+                    if (addedIndexObj.length > 0) {
+                      that._packets.dropIndex(addedIndexKeyString, function (error, result){
+                        if (error) {
+                          cb(error);
+                        }
+                        else {
+                          that._packets.createIndex(addedIndexKey, {expireAfterSeconds: Math.round(that.options.ttl.packets / 1000)}, cb);
+                        }
+                      });
+                    }
+                    else {
+                      that._packets.createIndex(addedIndexKey, {expireAfterSeconds: Math.round(that.options.ttl.packets / 1000)}, cb);
+                    }
+                  }
+                }
+              });
+
+            }
           ], cb);
         });
       },
@@ -287,6 +324,10 @@ MongoPersistence.prototype._storePacket = function(client, packet, cb) {
     packet: packet,
     added: new Date()
   };
+  //if (this.options.ttl.offlinePacketsTimeout != -1)
+  //{
+  //  toStore
+  //}
 
   this._packets.insert(toStore, {w:1}, cb);
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -99,6 +99,7 @@ function Server(opts, callback) {
   var modernOpts = options.modernize(opts);
   var validationResult = options.validate(modernOpts);
 
+
   if (validationResult.errors.length > 0) {
     var errMessage = validationResult.errors[0].message;
     callback(new Error(errMessage));
@@ -570,3 +571,8 @@ Server.prototype.nextDedupId = function() {
 Server.prototype.generateUniqueId = function() {
   return shortid.generate();
 };
+
+Server.prototype.setAgendaClient = function(agendaClient)
+{
+  this.agendaClient = agendaClient;
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -99,7 +99,6 @@ function Server(opts, callback) {
   var modernOpts = options.modernize(opts);
   var validationResult = options.validate(modernOpts);
 
-
   if (validationResult.errors.length > 0) {
     var errMessage = validationResult.errors[0].message;
     callback(new Error(errMessage));
@@ -197,7 +196,7 @@ function Server(opts, callback) {
 
         var server = interfaces.serverFactory(iface, fallback, that);
         that.servers.push(server);
-        server.maxConnections = 100000;
+        server.maxConnections = 10000000;
         server.listen(port, host, dn);
       }, done);
     },
@@ -571,8 +570,3 @@ Server.prototype.nextDedupId = function() {
 Server.prototype.generateUniqueId = function() {
   return shortid.generate();
 };
-
-Server.prototype.setAgendaClient = function(agendaClient)
-{
-  this.agendaClient = agendaClient;
-}

--- a/lib/server.js
+++ b/lib/server.js
@@ -197,7 +197,7 @@ function Server(opts, callback) {
 
         var server = interfaces.serverFactory(iface, fallback, that);
         that.servers.push(server);
-        server.maxConnections = 10000000;
+        server.maxConnections = 100000;
         server.listen(port, host, dn);
       }, done);
     },

--- a/lib/server.js
+++ b/lib/server.js
@@ -196,7 +196,7 @@ function Server(opts, callback) {
 
         var server = interfaces.serverFactory(iface, fallback, that);
         that.servers.push(server);
-        server.maxConnections = 100000;
+        server.maxConnections = 10000000;
         server.listen(port, host, dn);
       }, done);
     },


### PR DESCRIPTION
* Increased maxConnections to 10M, now no one should reach this limit.
* Offline message lifetime defaults to 1 hour, this patch makes it an option of the server settings so that you can easily manage and change it. Only valid for Mongo persistence.

> new mosca.Server({offlineMessageTimeout: 3600 * 1000}); //In miliseconds, this is one hour
