### PR TITLE
Handling of empty clientId for 3.1.1 connections

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -304,7 +304,30 @@ Client.prototype.handleConnect = function(packet, completeConnection) {
   var that = this, logger, client = this.connection;
 
   this.id = packet.clientId;
+
   this.logger = logger = that.logger.child({ client: this });
+
+  // for MQTT 3.1.1 (protocolVersion == 4) it is valid to receive an empty
+  // clientId if cleanSession is set to 1. In this case, Mosca should generate
+  // a random ID.
+  // Otherwise, the connection should be rejected.
+  if(!this.id) {
+    
+    if(packet.protocolVersion == 4 && packet.clean) {
+
+      this.id = ['anonymous', Date.now(), Math.floor(Math.random() * 1e6)].join('_');
+    } 
+    else {
+
+      logger.info("identifier rejected");
+      client.connack({
+        returnCode: 2
+      });
+      client.stream.end();
+      return;
+    }
+  }
+
 
   that.server.authenticate(this, packet.username, packet.password,
                            function(err, verdict) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -24,7 +24,8 @@ OTHER DEALINGS IN THE SOFTWARE.
 */
 "use strict";
 
-var async  = require("async");
+var async  = require("async"),
+    uuid = require("uuid");
 
 function nop() {}
 
@@ -315,7 +316,7 @@ Client.prototype.handleConnect = function(packet, completeConnection) {
     
     if(packet.protocolVersion == 4 && packet.clean) {
 
-      this.id = ['anonymous', Date.now(), Math.floor(Math.random() * 1e6)].join('_');
+      this.id = uuid.v4();
     } 
     else {
 

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "shortid": "^2.1.3",
     "st": "~0.5.1",
     "uglify-js": "^2.4.16",
+    "uuid": "^2.0.1",
     "websocket-stream": "^1.3.2"
   },
   "optionalDependencies": {


### PR DESCRIPTION
According to
http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/csprd02/mqtt-v3.1.1-csprd02.html#_Toc385349764

> A Server MAY allow a Client to supply a ClientId that has a length of
> zero bytes, however if it does so the Server MUST treat this as a
> special case and assign a unique ClientId to that Client. It MUST then
> process the CONNECT packet as if the Client had provided that unique
> ClientId [MQTT-3.1.3-6].

> If the Client supplies a zero-byte ClientId, the Client MUST also set
> CleanSession to 1 [MQTT-3.1.3-7].
>
> If the Client supplies a zero-byte ClientId with CleanSession set to 0,
> the Server MUST respond to the CONNECT Packet with a CONNACK return code
> 0x02 (Identifier rejected) and then close the Network Connection
> [MQTT-3.1.3-8].
>
> If the Server rejects the ClientId it MUST respond to the CONNECT Packet
> with a CONNACK return code 0x02 (Identifier rejected) and then close the
> Network Connection [MQTT-3.1.3-9].

I was a bit unsure of how to implement tests for this behavior. The test
for the generation of a random ID when legitimately providing an empty
one is done by observing the publishNewClient message.

I cannot easily provide a test for the rejection-case, because the
mqtt-packet module would not allow me to generate invalid connect
packages (namely `clientId: null` + `cleanSession: 0 || protocolVersion:
3`)