### PR TITLE
nextId can not be initialized with 0

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -45,7 +45,7 @@ function Client(conn, server) {
   this.logger = server.logger;
   this.subscriptions = {};
 
-  this.nextId = 0;
+  this.nextId = 1;
   this.inflight = {};
   this.inflightCounter = 0;
   this._lastDedupId = -1;


### PR DESCRIPTION
nextId can not be initialized as 0 otherwise there is strange behavior with QoS messages.. first published message is never deleted from persistance storage