### PR TITLE
Allowed bypassing TLS options 'requestCert' and 'rejectUnauthorized'

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -205,7 +205,9 @@ function validate(opts, validationOptions) {
     properties: {
       'keyPath': { type: 'string', required: true },
       'certPath': { type: 'string', required: true },
-      'caPaths': { type: 'array', required: false }
+      'caPaths': { type: 'array', required: false },
+      'requestCert': { type: 'boolean', required: false },
+      'rejectUnauthorized': { type: 'boolean', required: false }
     }
   });
 


### PR DESCRIPTION
I tried to enforce the authorisation by client certificates, so that just clients with an certificate signed by the CA are allowed to connect. In order to achieve this, I had to state the 'requestCert' and 'rejectUnauthorized' in the TLS server options.

This patch just allows to bypass these options through the JSON validator. It has been tested with the HTTPS and MQTTS interface and everything seems to work as expected.