### PR TITLE
Don't storeOffline retain, qos=0 messages, fixes #349

### DIFF
--- a/lib/persistence/abstract.js
+++ b/lib/persistence/abstract.js
@@ -68,7 +68,11 @@ AbstractPersistence.prototype.wire = function(server) {
       total++;
       that.storeRetained(packet, done);
     }
-    that.storeOfflinePacket(packet, done);
+    if (packet.qos !== 0 || that.options.storeMessagesQos0) {
+      total++;
+      that.storeOfflinePacket(packet, done);
+    }
+    done();
   };
 
   server.deleteOfflinePacket = function(client, messageId, cb) {

--- a/test/persistence/abstract.js
+++ b/test/persistence/abstract.js
@@ -1024,6 +1024,9 @@ module.exports = function(create, buildOpts) {
       server.persistClient(client, function() {
         server.storePacket(packet, function() {
           server.forwardRetained("hello/42", client);
+          instance.streamOfflinePackets(client, function(err, p) {
+            done(new Error("this should never be called"));
+          });
         });
       });
     });


### PR DESCRIPTION
I've changed to tests so this passes, @mcollina would you mind please check if that's Ok:

1) `inflight packets > should not delete the offline packets once streamed`: changed the packet qos to 1
2) `storeMessagesQos0 = false > qos 0, retain true`: changed `streamOfflinePackets` to `forwardRetained`