### PR TITLE
Allow passing additional option to tls.createServer

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -201,7 +201,7 @@ function validate(opts, validationOptions) {
   validator.addSchema({
     id: '/Credentials',
     type: 'object',
-    additionalProperties: false,
+    additionalProperties: true,
     properties: {
       'keyPath': { type: 'string', required: true },
       'certPath': { type: 'string', required: true },

--- a/lib/server.js
+++ b/lib/server.js
@@ -63,6 +63,7 @@ var nop = function() {};
  *  - `credentials`, credentials for secure connection, includes two properties:
  *     - `keyPath`, the path to the key
  *     - `certPath`, the path to the certificate
+ *     - `*`, additional properties are passed as options to `tls.createServer` (see https://nodejs.org/api/tls.html#tls_tls_createserver_options_secureconnectionlistener)
  *  - `stats`, publish the stats every 10s (default false).
  *  - `publishNewClient`, publish message to topic "$SYS/{broker-id}/new/clients" when new client connects.
  *  - `publishClientDisconnect`, publish message to topic "$SYS/{broker-id}/disconnect/clients" when a client disconnects.


### PR DESCRIPTION
This change allows passing additional options via credentials option
to the underlying tls.createServer call.
This allows things like restricting ciphers, enable client certificates, etc.