### PR TITLE
improve redis persistence wildcard match speed

### DIFF
--- a/lib/persistence/redis.js
+++ b/lib/persistence/redis.js
@@ -213,19 +213,53 @@ RedisPersistence.prototype.lookupRetained = function(pattern, done) {
     });
   };
 
+  // redis lua topic match script
+  // jshint multistr:true
+  var lua_script = "local cursor = 0 \
+    local response = {} \
+    local match \
+    local hscan \
+    repeat \
+      hscan = redis.call('HSCAN', KEYS[1], cursor, 'MATCH', ARGV[1]) \
+      cursor = tonumber(hscan[1]) \
+      match = hscan[2] \
+      if match then \
+        for idx = 1, #match, 2 do \
+          response[match[idx]] = match[idx + 1] \
+        end \
+      end \
+    until cursor == 0 \
+    return cjson.encode(response)";
+
   if (pattern.indexOf("#") >= 0 || pattern.indexOf("+") >= 0) {
+
     var matcher = new Matcher();
     matcher.add(pattern, true);
 
-    this._client.hkeys("retained", function(err, topics) {
-      topics.sort();
-      topics = topics.filter(function(topic) {
+    // replace wildcards with HSCAN match pattern wildcard
+    var hscan_pattern = pattern.replace(/[#\+]/g, '*');
+
+    // reduce the amount of keys returned by redis using the lua script
+    // jshint evil:true
+    that._client.eval(lua_script, 1, 'retained', hscan_pattern, function(err, filtered) {
+
+      if (err) {
+        return done(err);
+      }
+
+      filtered = JSON.parse(filtered);
+
+      // do final matching with JS
+      var matches = Object.keys(filtered).filter(function(topic) {
         return matcher.match(topic).length > 0;
+      }).map(function(topic) {
+        var packet = JSON.parse(filtered[topic]);
+        packet.payload = new Buffer(packet.payload);
+        return packet;
       });
 
-      async.each(topics, match, function(err) {
-        done(err, matched);
-      });
+      done(err, matches);
+
     });
 
     // do something

--- a/lib/persistence/redis.js
+++ b/lib/persistence/redis.js
@@ -250,7 +250,7 @@ RedisPersistence.prototype.lookupRetained = function(pattern, done) {
       filtered = JSON.parse(filtered);
 
       // do final matching with JS
-      var matches = Object.keys(filtered).filter(function(topic) {
+      var matches = Object.keys(filtered).sort().filter(function(topic) {
         return matcher.match(topic).length > 0;
       }).map(function(topic) {
         var packet = JSON.parse(filtered[topic]);


### PR DESCRIPTION
## changes
this branch reduces the amount of retained hash keys returned by redis in the redis persistence module by replacing the `HKEYS` call with a lua script that does some pre matching. the lua script also returns the associated values with the matched key results so the `async.each` `HGET` loop is avoided.

## benchmarks
i was benchmarking this change with 1 million retained hash keys, and it looks like `HKEYS` method is about 258% slower. the results are listed below so you can compare the results of the current `HKEYS` method vs the lua script:

```
created 1000000 hash keys

real	0m23.453s
user	0m11.763s
sys	0m11.694s

--------------------------------------  HKEYS  --------------------------------------
retrieved 1000000 hash keys via HKEYS
JS matched topic: 'topic/0.09308264800347388/999997' 
got value via HGET: 0.3918832363560796
result {"topic\/0.09308264800347388\/999997":"0.3918832363560796"}

real	0m3.460s
user	0m2.729s
sys	0m0.194s

----------------------------------------  LUA  ---------------------------------------
retrieved 1 hash keys via Lua
JS matched topic: 'topic/0.09308264800347388/999997' 
result {"topic\/0.09308264800347388\/999997":"0.3918832363560796"}

real	0m1.337s
user	0m0.116s
sys	0m0.024s
```