### PR TITLE
requestCert, rejectUnauthorized, caPaths fix

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -101,6 +101,15 @@ function modernize(legacy) {
     if (legacy.secure.hasOwnProperty('certPath')) {
       modernized.credentials.certPath = legacy.secure.certPath;
     }
+    if (legacy.secure.hasOwnProperty('caPaths')) {
+      modernized.credentials.caPaths = legacy.secure.caPaths;
+    }
+    if (legacy.secure.hasOwnProperty('requestCert')) {
+      modernized.credentials.requestCert = legacy.secure.requestCert;
+    }
+    if (legacy.secure.hasOwnProperty('rejectUnauthorized')) {
+      modernized.credentials.rejectUnauthorized = legacy.secure.rejectUnauthorized;
+    }
   } // else no credentials were provided
 
   // construct `interfaces`


### PR DESCRIPTION
Currently secure server allows to pass those options, but does not actually reject clients. This commit should fix the behavior.