### PR TITLE
Delete sent messages

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -264,19 +264,22 @@ Client.prototype._buildForward = function() {
 
       if (qos && options.messageId) {
 
-        //converting the payload to a JSON object
-        var packetPayload = JSON.parse(packet.payload.toString());
+        var messageId = options.messageId;
 
-        var messageId;
-
-        //if the oldMessageId is set in the payload, then use it to update
-        //the message id that was persisted and delete it from the payload
-        if (packetPayload.oldMessageId) {
-          messageId = packetPayload.oldMessageId;
-          delete packetPayload.oldMessageId;
-          packet.payload = new Buffer(JSON.stringify(packetPayload));
-        } else {
-          messageId = options.messageId;
+        try {
+          
+          //converting the payload to a JSON object
+          var packetPayload = JSON.parse(packet.payload.toString());
+          
+          //if the oldMessageId is set in the payload, then use it to update
+          //the message id that was persisted and delete it from the payload
+          if (packetPayload.oldMessageId) {
+            messageId = packetPayload.oldMessageId;
+            delete packetPayload.oldMessageId;
+            packet.payload = new Buffer(JSON.stringify(packetPayload));
+          }
+        } catch (ex) {
+          that.logger.debug("payload is not a valid json");
         }
 
         that.server.updateOfflinePacket(that, messageId, packet, doForward);

--- a/lib/client.js
+++ b/lib/client.js
@@ -263,7 +263,23 @@ Client.prototype._buildForward = function() {
       }
 
       if (qos && options.messageId) {
-        that.server.updateOfflinePacket(that, options.messageId, packet, doForward);
+
+        //converting the payload to a JSON object
+        var packetPayload = JSON.parse(packet.payload.toString());
+
+        var messageId;
+
+        //if the oldMessageId is set in the payload, then use it to update
+        //the message id that was persisted and delete it from the payload
+        if (packetPayload.oldMessageId) {
+          messageId = packetPayload.oldMessageId;
+          delete packetPayload.oldMessageId;
+          packet.payload = new Buffer(JSON.stringify(packetPayload));
+        } else {
+          messageId = options.messageId;
+        }
+
+        that.server.updateOfflinePacket(that, messageId, packet, doForward);
       } else {
         doForward(null, packet);
       }

--- a/lib/server.js
+++ b/lib/server.js
@@ -332,6 +332,18 @@ Server.prototype.publish = function publish(packet, client, callback) {
     qos: packet.qos,
     retain: packet.retain
   };
+  
+  //if the message being published is published to $SYS,
+  //payload is not a JSON string
+  //if the message is sent by a client, update the packet payload
+  //to include the message id of the newPacket
+  //which can be later used in client to delete the record from persistence
+  if (packet.topic.indexOf( '$SYS' ) === -1) {
+    var payload = packet.payload.toString();
+    payload = JSON.parse(payload);
+    payload.oldMessageId = newPacket.messageId;
+    packet.payload = new Buffer(JSON.stringify(payload));
+  }
 
   var opts = {
     qos: packet.qos,

--- a/lib/server.js
+++ b/lib/server.js
@@ -338,11 +338,15 @@ Server.prototype.publish = function publish(packet, client, callback) {
   //if the message is sent by a client, update the packet payload
   //to include the message id of the newPacket
   //which can be later used in client to delete the record from persistence
-  if (packet.topic.indexOf( '$SYS' ) === -1) {
-    var payload = packet.payload.toString();
-    payload = JSON.parse(payload);
-    payload.oldMessageId = newPacket.messageId;
-    packet.payload = new Buffer(JSON.stringify(payload));
+  try {
+    if (packet.topic.indexOf( '$SYS' ) === -1) {
+      var payload = packet.payload.toString();
+      payload = JSON.parse(payload);
+      payload.oldMessageId = newPacket.messageId;
+      packet.payload = new Buffer(JSON.stringify(payload));
+    }
+  } catch (ex) {
+    logger.debug({packet: packet}, "payload is not a valid json string");
   }
 
   var opts = {


### PR DESCRIPTION
If the publisher are subscriber are both online and the publisher sends
a message to the subscriber, the message is not deleted from the
backend store (found in both redid and mongo).

The reason was different messageIds were used for storing the packet in
server.js's publish method and updating the offline packet in
client.js's this.forward method.

Updated the publish method in server.js to include the messageId
generated for storing (for newPacket) and use it in the this.forward
method of client.js to update the packet using updateOfflinePacket
method.