### PR TITLE
Changed docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Mosca
 #
-# VERSION 0.1.0
+# VERSION 0.2.0
 
-FROM node:0.10
+FROM mhart/alpine-node:5.7
 MAINTAINER Matteo Collina <hello@matteocollina.com>
 
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
As discussed in #418 

Changed docker base image to arrive at a much smaller container.
I used mhart/alpine-node:5.7 as base image.
Dockerhub [reports the size as 30MB](https://hub.docker.com/r/seriousme/mosca/tags/) 
ImageLayers [reports the size as 49 MB](https://imagelayers.io/?images=matteocollina%2Fmosca:latest,seriousme%2Fmosca:latest)

Container succesfully launched on my local dockerhost.
Build log can be found [here](https://hub.docker.com/r/seriousme/mosca/builds/btcovueywfyjun8jwnj3sog/).