### PR TITLE
added default options to empty object

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -49,6 +49,9 @@ module.exports = {
  * @return {Object}         Modernized options
  */
 function modernize(legacy) {
+
+  legacy = legacy || {};
+
   var modernized = {};
 
   // "plain copyable" conserved options


### PR DESCRIPTION
to solve this problem:

```
[23:18:46] henricavalcante@machine:~/git/henricavalcante/talk-gdg-mqtt
$ node mosca1.js
/Users/henricavalcante/git/henricavalcante/talk-gdg-mqtt/node_modules/mosca/lib/options.js:68
    if (legacy.hasOwnProperty(name)) {
              ^

TypeError: Cannot read property 'hasOwnProperty' of undefined
    at /Users/henricavalcante/git/henricavalcante/talk-gdg-mqtt/node_modules/mosca/lib/options.js:68:15
    at Array.forEach (native)
    at Object.modernize (/Users/henricavalcante/git/henricavalcante/talk-gdg-mqtt/node_modules/mosca/lib/options.js:67:13)
    at EventEmitter.Server (/Users/henricavalcante/git/henricavalcante/talk-gdg-mqtt/node_modules/mosca/lib/server.js:101:28)
    at Object.<anonymous> (/Users/henricavalcante/git/henricavalcante/talk-gdg-mqtt/mosca1.js:2:16)
    at Module._compile (module.js:398:26)
    at Object.Module._extensions..js (module.js:405:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Function.Module.runMain (module.js:430:10)
```