### PR TITLE
configurable maxConnections per interface

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -123,6 +123,10 @@ function modernize(legacy) {
         mqtt_interface.port = legacy.port;
       }
 
+      if (legacy.hasOwnProperty('maxConnections')) {
+        mqtt_interface.maxConnections = legacy.maxConnections;
+      }
+
       modernized.interfaces.push(mqtt_interface);
     }
 
@@ -320,6 +324,7 @@ function defaultsLegacy() {
   return {
     port: 1883,
     host: null,
+    maxConnections: 10000000,
     backend: {
       json: false,
       wildcardOne: '+',
@@ -353,7 +358,7 @@ function defaultsModern() {
   return {
     host: null,
     interfaces: [
-      { type: "mqtt", port: 1883 }
+      { type: "mqtt", port: 1883, maxConnections: 10000000 }
     ],
     backend: {
       json: false,

--- a/lib/server.js
+++ b/lib/server.js
@@ -207,7 +207,7 @@ function Server(opts, callback) {
 
         var server = interfaces.serverFactory(iface, fallback, that);
         that.servers.push(server);
-        server.maxConnections = 10000000;
+        server.maxConnections = iface.maxConnections || 10000000;
         server.listen(port, host, dn);
       }, done);
     },

--- a/test/options.js
+++ b/test/options.js
@@ -56,7 +56,7 @@ describe("mocha.options", function () {
       expect(modern).to.have.property("interfaces");
       expect(modern.interfaces).to.be.deep.equal(
         [
-          { type: "mqtt", port: 1883 }
+          { type: "mqtt", port: 1883, maxConnections: 10000000 }
         ]
       );
     });


### PR DESCRIPTION
There's #303 which addresses similar feature. However, I didn't find a PR for that. 

In #303, it'd been discussed about removing the cap of maximum connections. The rationale of my modification intended to do the opposite. I want to limit the number of connenctions so that resources can be better managed.

With this PR, now you can set up maxConnections per interface in the config:
```json
{
    //...
    interfaces: [
      { type: "mqtt", port: 1883, maxConnections: 1000 }
    ],
    //...
}
```