### PR TITLE
observed HAProxy/Redis/Sentinel error on short timeouts or disconnect

### DIFF
--- a/lib/persistence/redis.js
+++ b/lib/persistence/redis.js
@@ -159,6 +159,8 @@ function RedisPersistence(options, callback) {
       }, function(err) {
         if (callback) {
           callback(err, that);
+          callback = null;
+          return;
         }
       });
     });


### PR DESCRIPTION
When HAProxy timeout is set to a very short value, or when connecting directly to Redis and Redis dies, observed the following exception:

Error: Callback was already called.
at /usr/src/thing-proxy/node_modules/ponte/node_modules/async/lib/async.js:43:36
at /usr/src/thing-proxy/node_modules/ponte/lib/ponte.js:42:7
at /usr/src/thing-proxy/node_modules/ponte/node_modules/mosca/lib/persistence/redis.js:161:11
at /usr/src/thing-proxy/node_modules/ponte/node_modules/async/lib/async.js:52:16
at Object.async.forEachOf.async.eachOf (/usr/src/thing-proxy/node_modules/ponte/node_modules/async/lib/async.js:236:30)
at Object.async.forEach.async.each (/usr/src/thing-proxy/node_modules/ponte/node_modules/async/lib/async.js:209:22)
[...]