### PR TITLE
add message to publish callback

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -380,7 +380,7 @@ Server.prototype.publish = function publish(packet, client, callback) {
             logger.debug({ packet: newPacket }, "published packet");
           }
           that.emit("published", newPacket, client);
-          callback();
+          callback(newPacket);
         });
       }
     );

--- a/lib/server.js
+++ b/lib/server.js
@@ -380,7 +380,7 @@ Server.prototype.publish = function publish(packet, client, callback) {
             logger.debug({ packet: newPacket }, "published packet");
           }
           that.emit("published", newPacket, client);
-          callback(newPacket);
+          callback(undefined, newPacket);
         });
       }
     );

--- a/test/server.js
+++ b/test/server.js
@@ -206,6 +206,24 @@ describe("mosca.Server", function() {
     });
   });
 
+  it("should provide packet in publish callback", function(done) {
+    var messageId;
+
+    this.instance.once("published", function(packet) {
+      messageId = packet.messageId;
+    });
+	
+    this.instance.publish({
+      topic: "hello",
+      payload: "some data"
+    }, function(error, packet) {
+      expect(packet.topic).to.be.equal("hello");
+      expect(packet.payload.toString().toString()).to.be.equal("some data");
+      expect(packet.messageId.toString()).to.equal(messageId);
+      done();
+    });
+  });
+
   describe("timers", function() {
     var clock;
 


### PR DESCRIPTION
allows the callback to get the generated message id or any other content.
i.e. usefully for filtering own published message from the published hook.

against the contribution guidelines, could not run tests for this commit. Currently have some problems with other dependencies.  Hope this small change didn't break anything. At least could find code that should break with this.