### PR TITLE
Fixbug (subscribes with same topic, may lead to the ascoltatore added multi cbs, and can't unsubscribe)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -443,19 +443,23 @@ Client.prototype.handleAuthorizeSubscribe = function(err, success, s, cb) {
     that.forward(topic, payload, options, s.topic, s.qos);
   };
 
-  this.server.ascoltatore.subscribe(
-    s.topic,
-    handler,
-    function(err) {
-      if (err) {
-        cb(err);
-        return;
+  if (this.subscriptions[s.topic] === undefined) {
+    this.subscriptions[s.topic] = { qos: s.qos, handler: handler };
+    this.server.ascoltatore.subscribe(
+      s.topic,
+      handler,
+      function(err) {
+        if (err) {
+          delete that.subscriptions[s.topic];
+          cb(err);
+          return;
+        }
+        that.logger.info({ topic: s.topic, qos: s.qos }, "subscribed to topic");
+        //that.subscriptions[s.topic] = { qos: s.qos, handler: handler };
+        cb(null, true);
       }
-      that.logger.info({ topic: s.topic, qos: s.qos }, "subscribed to topic");
-      that.subscriptions[s.topic] = { qos: s.qos, handler: handler };
-      cb(null, true);
-    }
-  );
+    );
+  }
 };
 
 function handleEachSub (s, cb) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -459,6 +459,8 @@ Client.prototype.handleAuthorizeSubscribe = function(err, success, s, cb) {
         cb(null, true);
       }
     );
+  } else {
+    cb(null, true);
   }
 };
 

--- a/test/server.js
+++ b/test/server.js
@@ -213,18 +213,14 @@ describe("mosca.Server", function() {
           });
         });
 
-        var donePass = false;
         client.on("publish", function(packet) { // should not receive the publish
-          client.disconnect();
-          donePass = true
-          done(new Error("unexpected publish"))
+          done(new Error("unexpected publish"));
         });
 
-        setTimeout(function(){
+        client.on("puback", function(packet) { // close client when puback
           client.disconnect();
-          if (!donePass)
-            done()
-        }, 1000);
+          done();
+        });
     });
   });
 


### PR DESCRIPTION
Hi mcollina, I find a bug with mosca.
if we continuously send multi subscribe messages with an same topic, sometimes it will add **multi callback** to ascoltatore and can't unsubscribed successfully.
More detail see the comment.