### PR TITLE
Explicit support of `redisClient({ url })`

### DIFF
--- a/lib/persistence/redis.js
+++ b/lib/persistence/redis.js
@@ -48,6 +48,7 @@ var defaults = {
  * A Redis-based persistance.
  *
  * The current options include:
+ *  - `url`, the redis' url (encompasses port/host/db/password).
  *  - `port`, the Redis' port.
  *  - `host`, the Redis' host.
  *  - `db`, the Redis' database.
@@ -196,6 +197,10 @@ util.inherits(RedisPersistence, AbstractPersistence);
 RedisPersistence.prototype._buildClient = function() {
   var options = this.options.redisOptions || {};
 
+  if (this.options.url) {
+    options.url = this.options.url;
+  }
+  
   if (this.options.host) {
     options.host = this.options.host;
   }


### PR DESCRIPTION
Merging this would require to alter the content of https://github.com/mcollina/mosca/wiki/Mosca-advanced-usage.

fixes #571 