### PR TITLE
enable docker hub builds for Raspberry Pi

### DIFF
--- a/Dockerfile-rpi-hub
+++ b/Dockerfile-rpi-hub
@@ -1,0 +1,25 @@
+# Mosca
+#
+# VERSION 0.2.1
+
+FROM ma314smith/rpi2-node-qemu:4
+MAINTAINER Matteo Collina <hello@matteocollina.com>
+
+RUN [ "cross-build-start" ]
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app/
+
+COPY ./ /usr/src/app/
+
+RUN apt-get update && \
+    apt-get install make gcc g++ python git && \
+    npm install --unsafe-perm --production && \
+    apt-get remove make gcc g++ python git
+
+EXPOSE 80
+EXPOSE 1883
+
+ENTRYPOINT ["/usr/src/app/bin/mosca", "-d", "/db", "--http-port", "80", "--http-bundle", "-v"]
+
+RUN [ "cross-build-end" ]


### PR DESCRIPTION
This will allow ARM cross-builds on the docker hub. See my fork here: https://hub.docker.com/r/ma314smith/mosca/builds/

If anyone is using the current Dockerfile-rpi to build locally (`docker build -t mosca -f Dockerfile-rpi https://github.com/mcollina/mosca.git`), then this will break that process.  If you'd prefer, I can update the PR with a new dockerfile instead (Dockerfile-rpi-hub?).