### PR TITLE
Created clientError event (fixes #609)

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -130,7 +130,7 @@ Client.prototype._setup = function() {
     });
 
     function handleError(err) {
-      that.logger.warn(err);
+      that.server.emit("clientError", err, that);
       that.onNonDisconnectClose(err.message);
     }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -86,6 +86,8 @@ var nop = function() {};
  *    the client is passed as a parameter.
  *  - `clientDisconnected`, when a client is disconnected;
  *    the client is passed as a parameter.
+ *  - `clientError`, when the server identifies a client connection error;
+ *    the error and the client are passed as parameters.
  *  - `published`, when a new message is published;
  *    the packet and the client are passed as parameters.
  *  - `subscribed`, when a client is subscribed to a topic;

--- a/test/server.js
+++ b/test/server.js
@@ -282,7 +282,7 @@ describe("mosca.Server", function() {
   it("should emit \"clientError\" when client error occurs due to unexpected disconnection", function(done) {
     // listen to a client error event
     this.instance.once("clientError", function(error, client) {
-      expect(error).to.be.instanceof(Error);
+      expect(error).to.be.an('error');
       done();
     });
     // cause a connection error between client and server, leading to a socket hang up

--- a/test/server.js
+++ b/test/server.js
@@ -289,7 +289,16 @@ describe("mosca.Server", function() {
     // cause a connection error between client and server, leading to a socket hang up
     require('child_process').spawn('sh', [ '-c',
         'node -e ' +
-          '"var createConnection = require(\'' + __dirname.replace(/\\/g, "/") + '/helpers/createConnection\');' +
+          '"var Connection = require(\'mqtt-connection\');' +
+          'var net = require(\'net\');' +
+          'function createConnection(port) {' +
+            'var stream = net.createConnection(port);' +
+            'var conn = new Connection(stream);' +
+            'stream.on(\'connect\', function() {' +
+              'conn.emit(\'connected\');' +
+            '});' +
+            'return conn;' +
+          '}' +
           'var client = createConnection(' + instance.opts.port + ');' +
           'client.on(\'connected\', function() {' +
             'client.connect({' +

--- a/test/server.js
+++ b/test/server.js
@@ -286,33 +286,10 @@ describe("mosca.Server", function() {
       expect(error).to.be.an('error');
       done();
     });
-    // cause a connection error between client and server, leading to a socket hang up
-    require('child_process').spawn('sh', [ '-c',
-        'node -e ' +
-          '"var Connection = require(\'mqtt-connection\');' +
-          'var net = require(\'net\');' +
-          'function createConnection(port) {' +
-            'var stream = net.createConnection(port);' +
-            'var conn = new Connection(stream);' +
-            'stream.on(\'connect\', function() {' +
-              'conn.emit(\'connected\');' +
-            '});' +
-            'return conn;' +
-          '}' +
-          'var client = createConnection(' + instance.opts.port + ');' +
-          'client.on(\'connected\', function() {' +
-            'client.connect({' +
-              'keepalive: 1000,' +
-              'clientId: \'mosca_' + require("crypto").randomBytes(8).toString('hex') + '\',' +
-              'protocolId: \'MQIsdp\',' +
-              'protocolVersion: 3' +
-            '});' +
-            'client.on(\'connack\', function(packet) {' +
-              'throw new Error();' +
-            '});' +
-          '});"'
-      ]
-    );
+    // cause a connection error between client and server
+    buildAndConnect(function () {}, instance, function(client) {
+      instance.clients[client.opts.clientId]['connection'].emit("error", new Error());
+    });
   });
 
   describe("timers", function() {

--- a/test/server.js
+++ b/test/server.js
@@ -280,8 +280,9 @@ describe("mosca.Server", function() {
   });
 
   it("should emit \"clientError\" when client error occurs due to unexpected disconnection", function(done) {
+    var instance = this.instance;
     // listen to a client error event
-    this.instance.once("clientError", function(error, client) {
+    instance.once("clientError", function(error, client) {
       expect(error).to.be.an('error');
       done();
     });


### PR DESCRIPTION
This change creates a new event called `clientError` which can be catch in the broker code by:

    // fired when client encounters an error
    server.on('clientError', function(error, client) {
        // handle the output message   
    });

This way the user will not have unexpected messages coming from `that.logger.warn(err);`.

Thank you for the awesome library!