### PR TITLE
fix: options missing when called storage backend

### DIFF
--- a/lib/persistence/redis.js
+++ b/lib/persistence/redis.js
@@ -197,24 +197,24 @@ util.inherits(RedisPersistence, AbstractPersistence);
 RedisPersistence.prototype._buildClient = function() {
   var options = this.options.redisOptions || {};
 
-  if (this.options.url) {
-    options.url = this.options.url;
-  }
-  
-  if (this.options.host) {
-    options.host = this.options.host;
+  if (this.options.backend.url) {
+    options.url = this.options.backend.url;
   }
 
-  if (this.options.port) {
-    options.port = this.options.port;
+  if (this.options.backend.host) {
+    options.host = this.options.backend.host;
   }
 
-  if (this.options.db) {
-    options.db = this.options.db;
+  if (this.options.backend.port) {
+    options.port = this.options.backend.port;
   }
 
-  if (this.options.password) {
-    options.password = this.options.password;
+  if (this.options.backend.db) {
+    options.db = this.options.backend.db;
+  }
+
+  if (this.options.backend.password) {
+    options.password = this.options.backend.password;
   }
 
   return new Redis(options);

--- a/lib/server.js
+++ b/lib/server.js
@@ -192,6 +192,9 @@ function Server(opts, callback) {
           }
         }
 
+        // make sure storage backend get options
+        that.modernOpts.persistence.backend = opts.backend
+
         that.persistence = persistenceFactory(that.modernOpts.persistence, done);
         that.persistence.wire(that);
       } else {
@@ -618,7 +621,7 @@ Server.prototype.attachHttpServer = function(server, path) {
   if (path) {
     opt.path = path;
   }
-  
+
   ws.createServer(opt, function(stream) {
     var conn = new Connection(stream);
     new Client(conn, that);


### PR DESCRIPTION
Currently when you call the example redis implementations, I believe the options won't get passed through. You can easily miss this locally, as redis for example is just calling its defaults. However, setting password is silent fail.

The expectation from the redis example is that all options from the ascoltatore object gets passed down.

Though this fix fixed the redis problem I would maybe rather recommend modernisation around inheritance and option passing. But I know you know what best to do. I offer my help, as I am currently doing a lot with MQTT in a my day job.

Example:
```js
var mosca = require('./')

var ascoltatore = {
  type: 'redis',
  redis: require('redis'),
  db: 12,
  port: 6379,
  return_buffers: true, // to handle binary payloads
  host: "localhost",
  password: 'hello'
};

var moscaSettings = {
  port: 1883,
  backend: ascoltatore,
  persistence: {
    factory: mosca.persistence.Redis
  }
};

var server = new mosca.Server(moscaSettings);
server.on('ready', setup);

server.on('clientConnected', function(client) {
	console.log('client connected', client.id);
});

// fired when a message is received
server.on('published', function(packet, client) {
  console.log('Published', packet.topic, packet.payload);
});

// fired when the mqtt server is ready
function setup() {
  console.log('Mosca server is up and running')
}

```
