### PR TITLE
remove moment

### DIFF
--- a/lib/stats.js
+++ b/lib/stats.js
@@ -25,7 +25,6 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 "use strict";
 
-var moment = require("moment");
 var movingAverage = require("moving-average");
 var version = "mosca " + require("../package").version;
 
@@ -159,8 +158,6 @@ Stats.prototype.wire = function wire(server) {
     });
   }
 
-  var mom = moment(this.started);
-
   var timer = setInterval(function() {
     var stats = server.stats;
     var mem = process.memoryUsage();
@@ -179,7 +176,7 @@ Stats.prototype.wire = function wire(server) {
 
     doPublish("version", version);
     doPublish("started_at", server.stats.started.toISOString());
-    doPublish("uptime", mom.from(Date.now(), true));
+    doPublish("uptime", Math.ceil((Date.now() - this.started) / 1000) + ' seconds');
     doPublish("clients/maximum", stats.maxConnectedClients);
     doPublish("clients/connected", stats.connectedClients);
     doPublish("publish/received", stats.publishedMessages);

--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "lru-cache": "~4.0.0",
     "memdown": "~1.1.1",
     "minimatch": "~3.0.0",
-    "moment": "~2.13.0",
     "moving-average": "0.1.1",
     "mqtt": "^1.6.3",
     "mqtt-connection": "^2.1.1",


### PR DESCRIPTION
Very tiny nit: I came by this line and thought it might be a little overkill. Removing moment from this one single line has a 2mb node_moulues decrease when installed without production flag.