### PR TITLE
Allow published messages on an unauthorised publish topic to be pubacked

### DIFF
--- a/examples/Server_With_All_Interfaces-Settings.js
+++ b/examples/Server_With_All_Interfaces-Settings.js
@@ -35,11 +35,20 @@ var authenticate = function (client, username, password, callback) {
 }
 
 var authorizePublish = function (client, topic, payload, callback) {
-    callback(null, true);
+    var auth = true;
+    // set auth to :
+    //  true to allow, 
+    //  false to deny and disconnect, 
+    //  'ignore' to puback but not publish msg.
+    callback(null, auth);
 }
 
 var authorizeSubscribe = function (client, topic, callback) {
-    callback(null, true);
+    var auth = true;
+    // set auth to :
+    //  true to allow, 
+    //  false to deny, 
+    callback(null, auth);
 }
 
 var server = new mosca.Server(moscaSetting);

--- a/examples/Server_With_All_Interfaces-Settings.js
+++ b/examples/Server_With_All_Interfaces-Settings.js
@@ -37,8 +37,8 @@ var authenticate = function (client, username, password, callback) {
 var authorizePublish = function (client, topic, payload, callback) {
     var auth = true;
     // set auth to :
-    //  true to allow, 
-    //  false to deny and disconnect, 
+    //  true to allow 
+    //  false to deny and disconnect
     //  'ignore' to puback but not publish msg.
     callback(null, auth);
 }
@@ -46,8 +46,8 @@ var authorizePublish = function (client, topic, payload, callback) {
 var authorizeSubscribe = function (client, topic, callback) {
     var auth = true;
     // set auth to :
-    //  true to allow, 
-    //  false to deny, 
+    //  true to allow
+    //  false to deny 
     callback(null, auth);
 }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -523,6 +523,7 @@ Client.prototype.handleSubscribe = function(packet) {
 Client.prototype.handleAuthorizePublish = function(err, success, packet) {
   var that = this;
 
+  // if err is passed, or success is false or undefined, terminate the connection
   if (err || !success) {
     if (!this._closed && !this._closing) {
       that.close(null, (err && err.message) || "publish not authorized");
@@ -534,13 +535,23 @@ Client.prototype.handleAuthorizePublish = function(err, success, packet) {
     packet.payload = success;
   }
 
-  that.server.publish(packet, that, function() {
+  var dopuback = function() {
     if (packet.qos === 1 && !(that._closed || that._closing)) {
       that.connection.puback({
         messageId: packet.messageId
       });
     }
-  });
+  };  
+  
+  
+  // if success is passed as 'suppress' ack but don't publish.
+  if (success !== 'suppress'){
+    // publish message
+    that.server.publish(packet, that, dopuback);
+  } else {
+    // ignore but acknowledge message
+    dopuback();
+  }
 };
 
 /**

--- a/lib/client.js
+++ b/lib/client.js
@@ -544,8 +544,8 @@ Client.prototype.handleAuthorizePublish = function(err, success, packet) {
   };  
   
   
-  // if success is passed as 'suppress' ack but don't publish.
-  if (success !== 'suppress'){
+  // if success is passed as 'ignore', ack but don't publish.
+  if (success !== 'ignore'){
     // publish message
     that.server.publish(packet, that, dopuback);
   } else {


### PR DESCRIPTION
A simple change to the client which if passed success === 'ignore' (as a string) from the user's authorizePublish function, will puback the message but not publish it.

This solves an issue for me where if a message is published to an unauthorized topic, the broker in node-red is disconnected (and does not reconnect).  Since the broker module in NR could be serving multiple clients, one rouge flow can kill all access to the MQTT server.

Of course, you can have no way to know your message was not published apart from custom server code...

It goes some way towards:
'Client connection closed if publish is not authorized #596'

example authorize function:

```
var authorizePublish = function(client, topic, payload, callback) {
  var auth = 'ignore';
  if (client.token){
    if (client.token.data){
      if (client.token.data.write){
        client.token.data.write.forEach(function(grant){
          if (grantvalid(topic, grant)){
            auth = true;
          }
          });
       }
    }
  }

  console.log("auth "+auth+" for Pub topic " + topic + " client allowed " + util.inspect(client.token));

  callback(null, auth);
}
```



