### PR TITLE
Add option 'qos2Puback' - if set to true, will modify published messages to …

### DIFF
--- a/examples/Server_With_All_Interfaces-Settings.js
+++ b/examples/Server_With_All_Interfaces-Settings.js
@@ -19,6 +19,7 @@ var moscaSetting = {
         { type: "https", port: 3001, bundle: true, credentials: { keyPath: SECURE_KEY, certPath: SECURE_CERT } }
     ],
     stats: false,
+    qos2Puback: false, // can set to true if using a client which will eat puback for QOS 2; e.g. mqtt.js
 
     logger: { name: 'MoscaServer', level: 'debug' },
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -535,6 +535,15 @@ Client.prototype.handleAuthorizePublish = function(err, success, packet) {
   }
 
   that.server.publish(packet, that, function() {
+  // if maxqos is set, then reduce qos to that.
+  // i.e. if qos 2, don't just ignore the message, puback it.
+  // this fools mqtt.js
+  if (that.server.modernOpts.maxqos !== undefined){
+      if (packet.qos > that.server.modernOpts.maxqos){
+          packet.qos = that.server.modernOpts.maxqos;
+      }
+  }
+
     if (packet.qos === 1 && !(that._closed || that._closing)) {
       that.connection.puback({
         messageId: packet.messageId

--- a/lib/client.js
+++ b/lib/client.js
@@ -535,14 +535,14 @@ Client.prototype.handleAuthorizePublish = function(err, success, packet) {
   }
 
   that.server.publish(packet, that, function() {
-  // if maxqos is set, then reduce qos to that.
-  // i.e. if qos 2, don't just ignore the message, puback it.
-  // this fools mqtt.js
-  if (that.server.modernOpts.maxqos !== undefined){
-      if (packet.qos > that.server.modernOpts.maxqos){
-          packet.qos = that.server.modernOpts.maxqos;
+    // if qos2Puback, then if qos 2, don't just ignore the message, puback it
+    // by converting internally to qos 1.
+    // this fools mqtt.js into not holding all messages forever
+    if (that.server.qos2Puback === true){
+      if (packet.qos === 2){
+          packet.qos = 1;
       }
-  }
+    }
 
     if (packet.qos === 1 && !(that._closed || that._closing)) {
       that.connection.puback({

--- a/lib/options.js
+++ b/lib/options.js
@@ -369,7 +369,7 @@ function defaultsModern() {
     publishClientDisconnect: true,
     publishSubscriptions: true,
     maxInflightMessages: 1024,
-    qos2Puback: 2,
+    qos2Puback: false,
     logger: {
       name: "mosca",
       level: "warn",

--- a/lib/options.js
+++ b/lib/options.js
@@ -63,7 +63,7 @@ function modernize(legacy) {
     "publishNewClient",
     "publishClientDisconnect",
     "publishSubscriptions",
-    "maxqos"
+    "qos2Puback"
   ];
 
   // copy all conserved options
@@ -254,7 +254,7 @@ function validate(opts, validationOptions) {
       'publishNewClient': { type: 'boolean' },
       'publishClientDisconnect': { type: 'boolean' },
       'publishSubscriptions': { type: 'boolean' },
-      'maxqos': { type: 'integer' },
+      'qos2Puback': { type: 'boolean' },
     }
   });
 
@@ -332,7 +332,7 @@ function defaultsLegacy() {
     publishClientDisconnect: true,
     publishSubscriptions: true,
     maxInflightMessages: 1024,
-    maxqos: 2,
+    qos2Puback: false,
     logger: {
       name: "mosca",
       level: "warn",
@@ -369,7 +369,7 @@ function defaultsModern() {
     publishClientDisconnect: true,
     publishSubscriptions: true,
     maxInflightMessages: 1024,
-    maxqos: 2,
+    qos2Puback: 2,
     logger: {
       name: "mosca",
       level: "warn",

--- a/lib/options.js
+++ b/lib/options.js
@@ -62,7 +62,8 @@ function modernize(legacy) {
     "stats",
     "publishNewClient",
     "publishClientDisconnect",
-    "publishSubscriptions"
+    "publishSubscriptions",
+    "maxqos"
   ];
 
   // copy all conserved options
@@ -252,7 +253,8 @@ function validate(opts, validationOptions) {
       'stats': { type: 'boolean' },
       'publishNewClient': { type: 'boolean' },
       'publishClientDisconnect': { type: 'boolean' },
-      'publishSubscriptions': { type: 'boolean' }
+      'publishSubscriptions': { type: 'boolean' },
+      'maxqos': { type: 'integer' },
     }
   });
 
@@ -330,6 +332,7 @@ function defaultsLegacy() {
     publishClientDisconnect: true,
     publishSubscriptions: true,
     maxInflightMessages: 1024,
+    maxqos: 2,
     logger: {
       name: "mosca",
       level: "warn",
@@ -366,6 +369,7 @@ function defaultsModern() {
     publishClientDisconnect: true,
     publishSubscriptions: true,
     maxInflightMessages: 1024,
+    maxqos: 2,
     logger: {
       name: "mosca",
       level: "warn",

--- a/lib/server.js
+++ b/lib/server.js
@@ -158,6 +158,9 @@ function Server(opts, callback) {
 
   var that = this;
 
+  // put QOS-2 spoofing as a variable direct on server
+  this.qos2Puback = this.modernOpts.qos2Puback;
+  
   // each Server has a dummy id for logging purposes
   this.id = this.modernOpts.id || shortid.generate();
 

--- a/test/abstract_server.js
+++ b/test/abstract_server.js
@@ -852,6 +852,90 @@ module.exports = function(moscaSettings, createConnection) {
     });
   });
 
+  it("should by default not puback client publish to QOS 2", function(done) {
+    var onPublishedCalled = false;
+    var clientId;
+    var count = 0;
+    var timer;
+
+    instance.published = function(packet, serverClient, callback) {
+      onPublishedCalled = true;
+      expect(packet.topic).to.be.equal("testQOS2");
+      callback();
+    };
+
+    buildAndConnect(done, function(client) {
+      clientId = client.opts.clientId;
+
+      client.publish({
+        messageId: 42,
+        topic: "testQOS2",
+        payload: "publish expected",
+        qos: 2
+      });
+
+      // allow 1 second to hear puback
+      timer = setTimeout(function(){
+        client.disconnect();
+      }, 1000);
+      
+      // default QOS 2 should NOT puback
+      client.on("puback", function() {
+        count++;
+        //expect(count).to.eql(1);
+        client.disconnect();
+      });
+      client.on("close", function() {
+        expect(count).to.eql(0);
+        client.disconnect();
+        clearTimeout(timer);
+      });
+    });
+  });
+
+  
+  it("should optionally (.qos2Puback) puback client publish to QOS 2", function(done) {
+    var onPublishedCalled = false;
+    var clientId;
+    var count = 0;
+    var timer;
+
+    instance.qos2Puback = true;
+    instance.published = function(packet, serverClient, callback) {
+      onPublishedCalled = true;
+      expect(packet.topic).to.be.equal("testQOS2");
+      callback();
+    };
+
+    buildAndConnect(done, function(client) {
+      clientId = client.opts.clientId;
+
+      client.publish({
+        messageId: 42,
+        topic: "testQOS2",
+        payload: "publish expected",
+        qos: 2
+      });
+
+      // allow 1 second to hear puback
+      timer = setTimeout(function(){
+        client.disconnect();
+      }, 1000);
+      
+      // with maxqos=1, QOS 2 should puback
+      client.on("puback", function() {
+        count++;
+        expect(count).to.eql(1);
+        client.disconnect();
+      });
+      client.on("close", function() {
+        expect(count).to.eql(1);
+        client.disconnect();
+        clearTimeout(timer);
+      });
+    });
+  });
+  
   it("should emit an event when a new client is connected", function(done) {
     buildClient(done, function(client) {
 


### PR DESCRIPTION
Add option 'qos2Puback' - if set to true, will modify published qos 2 messages to qos 1 before processing.
This results in the messages getting a puback, which fools mqtt.js into not getting stuck when sending qos 2 to mosca.
It's an option because the spec does not allow for this?  Probably will not suit all clients, but better than mqtt.js dying; a patch over the issue until mosca can get true QOS-2 or QOS-2 pseudo-processing.

