### PR TITLE
Minor - 'nextId' should always fit in 'uint16'

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -218,7 +218,7 @@ Client.prototype._buildForward = function() {
         forward = true,
         newId = this.nextId++;
 
-    // Make sure 'nextId' always fits in a uint8 (http://git.io/vmgKI).
+    // Make sure 'nextId' always fits in a uint16 (http://git.io/vmgKI).
     this.nextId %= 65536;
 
     var packet = {


### PR DESCRIPTION
Very minor thing, just for the sake of correctness :)
`nextId` is rather a `uint16`