### PR TITLE
Adding retain flag to retained messages

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -225,7 +225,8 @@ Client.prototype._buildForward = function() {
       topic: topic,
       payload: payload,
       qos: qos,
-      messageId: newId
+      messageId: newId,
+      retain: options.retain
     };
 
     if (qos) {


### PR DESCRIPTION
Retained messages sent to the client do not contain the retain flag set to true.