### PR TITLE
Catch exception on server start

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,22 @@
 language: node_js
 sudo: false
 node_js:
-  - 0.12
-  - 4
-  - 6
   - 8
 services:
   - redis-server
+  - mongodb  
 script:
   - npm run coverage
 after_success:
   - npm run publish-coverage
 env:
-  global:
-    - CC=gcc-4.8
-    - CXX=g++-4.8
-    - MONGODB_VERSION="3.4.9"
+  - CXX=g++-4.8
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - gcc-4.8
       - g++-4.8
       - libzmq3-dev
 before_install:
-  - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-$MONGODB_VERSION.tgz
-  - tar xfz mongodb-linux-x86_64-$MONGODB_VERSION.tgz
-  - export PATH=`pwd`/mongodb-linux-x86_64-$MONGODB_VERSION/bin:$PATH
-  - mkdir -p data/db
-  - mongod --dbpath=data/db > /dev/null &
   - sleep 5

--- a/lib/server.js
+++ b/lib/server.js
@@ -216,6 +216,12 @@ function Server(opts, callback) {
         var server = interfaces.serverFactory(iface, fallback, that);
         that.servers.push(server);
         server.maxConnections = iface.maxConnections || 10000000;
+        
+        // Catch listen errors
+        server.on('error', function (e) {
+          that.logger.error('Error starting Mosca Server');
+          that.emit('error', e);
+        });        
         server.listen(port, host, dn);
       }, done);
     },


### PR DESCRIPTION
In case of the use of mosca embedded in another program, an unhandled exception causes the main program to fail. Currently, this prevents node-red from being started if a port is already in use. With this change the exception can be caught with `server.on('error', ...`