### PR TITLE
Include TLS in options to build Redis client

### DIFF
--- a/lib/persistence/redis.js
+++ b/lib/persistence/redis.js
@@ -217,6 +217,10 @@ RedisPersistence.prototype._buildClient = function() {
     options.password = this.options.password;
   }
 
+  if (this.options.tls) {
+    options.tls = this.options.tls;
+  }
+
   return new Redis(options);
 };
 


### PR DESCRIPTION
Note that additionally the `ioredis` dependency needs to be upgraded to the latest version supporting the `rediss` protocol for the Redis connection URL.